### PR TITLE
Add multisite and images support and other fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add support for oc 1.
 * Fixed bug where sitemap would never regenerate when sitemap file exists.
 * Escape illegal xml characters in loc and title elements.
+* Log exception with stack trace and show 500 error when an error occurs.
 
 ## [2.0.0] - 2021-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0]
+
+* Add support for images.
+* Add sitemap config resolver to configure the sitemap config on runtime. This can be useful for multisite projects.
+* Fixed bug where sitemap would never regenerate when sitemap file exists.
+* Add support for oc 1
+
 ## [2.0.0] - 2021-07-13
 
-* Add support for PHP 7.4 or higher. Please review plugin configuration, check README.md 
+* Add support for PHP 7.4 or higher. Please review plugin configuration, check README.md
 
 ## [1.1.0] - 2021-05-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.2.0]
+## [2.2.0] - 2022-11-15
 
 * Add support for images.
 * Add sitemap config resolver to configure the sitemap config on runtime. This can be useful for multisite projects.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Add support for images.
 * Add sitemap config resolver to configure the sitemap config on runtime. This can be useful for multisite projects.
+* Add support for oc 1.
 * Fixed bug where sitemap would never regenerate when sitemap file exists.
-* Add support for oc 1
+* Escape illegal xml characters in loc and title elements.
 
 ## [2.0.0] - 2021-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Add support for images.
 * Add sitemap config resolver to configure the sitemap config on runtime. This can be useful for multisite projects.
 * Add support for oc 1.
+* Add support for priority zero.
 * Fixed bug where sitemap would never regenerate when sitemap file exists.
 * Escape illegal xml characters in loc and title elements.
 * Log exception with stack trace and show 500 error when an error occurs.

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@
 
 ## Requirements
 
-- PHP 8.0.2 or higher
-- October CMS 2.x or 3.x
+- PHP 8.0 or higher
+- October CMS 1.1 or higher
 
 ## Usage
 

--- a/ServiceProvider.php
+++ b/ServiceProvider.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Vdlp\Sitemap;
 
+use Illuminate\Contracts\Config\Repository;
+use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\ServiceProvider as ServiceProviderBase;
 use Vdlp\Sitemap\Classes\Contracts;
 use Vdlp\Sitemap\Classes\SitemapGenerator;
@@ -19,6 +21,15 @@ final class ServiceProvider extends ServiceProviderBase
 
     public function register(): void
     {
+        $this->mergeConfigFrom(__DIR__ . '/config.php', 'sitemap');
+
         $this->app->alias(SitemapGenerator::class, Contracts\SitemapGenerator::class);
+
+        $this->app->bind(Contracts\ConfigResolver::class, static function (Application $app): Contracts\ConfigResolver {
+            /** @var Repository $config */
+            $config = $app->make(Repository::class);
+
+            return $app->make($config->get('sitemap.config_resolver'));
+        });
     }
 }

--- a/classes/SitemapGenerator.php
+++ b/classes/SitemapGenerator.php
@@ -205,7 +205,7 @@ final class SitemapGenerator implements SitemapGeneratorInterface
             }
 
             if ($definition->getPriorityFloat() !== null) {
-                $xml .= '<priority>' . $definition->getPriorityFloat() . '</priority>';
+                $xml .= '<priority>' . number_format($definition->getPriorityFloat(), 1) . '</priority>';
             }
 
             if ($definition->getChangeFrequency() !== null) {

--- a/classes/SitemapGenerator.php
+++ b/classes/SitemapGenerator.php
@@ -197,7 +197,7 @@ final class SitemapGenerator implements SitemapGeneratorInterface
             $xml = '<url>';
 
             if ($definition->getUrl() !== null) {
-                $xml .= '<loc>' . $definition->getUrl() . '</loc>';
+                $xml .= '<loc>' . htmlspecialchars($definition->getUrl(), ENT_XML1, 'UTF-8') . '</loc>';
             }
 
             if ($definition->getModifiedAt() !== null) {
@@ -214,10 +214,14 @@ final class SitemapGenerator implements SitemapGeneratorInterface
 
             foreach ($definition->getImages() as $image) {
                 $xml .= '<image:image>';
-                $xml .= '<image:loc>' . $image->getUrl() . '</image:loc>';
+                $xml .= '<image:loc>'
+                    . htmlspecialchars($image->getUrl(), ENT_XML1, 'UTF-8')
+                    . '</image:loc>';
 
                 if ($image->getTitle() !== null) {
-                    $xml .= '<image:title>' . $image->getTitle() . '</image:title>';
+                    $xml .= '<image:title>'
+                        . htmlspecialchars($image->getTitle(), ENT_XML1, 'UTF-8')
+                        . '</image:title>';
                 }
 
                 $xml .= '</image:image>';

--- a/classes/SitemapGenerator.php
+++ b/classes/SitemapGenerator.php
@@ -9,30 +9,28 @@ use Illuminate\Contracts\Cache\Repository;
 use Illuminate\Contracts\Events\Dispatcher;
 use Psr\SimpleCache\InvalidArgumentException;
 use RuntimeException;
+use Vdlp\Sitemap\Classes\Contracts\ConfigResolver;
 use Vdlp\Sitemap\Classes\Contracts\DefinitionGenerator;
 use Vdlp\Sitemap\Classes\Contracts\SitemapGenerator as SitemapGeneratorInterface;
 use Vdlp\Sitemap\Classes\Dto\Definition;
 use Vdlp\Sitemap\Classes\Dto\Definitions;
+use Vdlp\Sitemap\Classes\Dto\SitemapConfig;
 use Vdlp\Sitemap\Classes\Exceptions\DtoNotFound;
 use Vdlp\Sitemap\Classes\Exceptions\InvalidGenerator;
 
 final class SitemapGenerator implements SitemapGeneratorInterface
 {
-    private const CACHE_KEY_SITEMAP = 'vdlp_sitemap_cache';
-    private const CACHE_DEFINITIONS = 'vdlp_sitemap_definitions';
-    private const VDLP_SITEMAP_PATH = 'vdlp/sitemap/sitemap.xml';
-
     private Repository $cache;
-    private Dispatcher $event;
-    private int $cacheTime;
-    private bool $cacheForever;
 
-    public function __construct(Repository $cache, Dispatcher $event)
+    private Dispatcher $event;
+
+    private SitemapConfig $sitemapConfig;
+
+    public function __construct(Repository $cache, Dispatcher $event, ConfigResolver $configResolver)
     {
         $this->cache = $cache;
         $this->event = $event;
-        $this->cacheTime = (int) config('sitemap.cache_time', 3600);
-        $this->cacheForever = (bool) config('sitemap.cache_forever', false);
+        $this->sitemapConfig = $configResolver->getConfig();
     }
 
     public function invalidateCache(): bool
@@ -46,12 +44,12 @@ final class SitemapGenerator implements SitemapGeneratorInterface
     public function generate(): void
     {
         try {
-            $fromCache = $this->cache->has(self::CACHE_KEY_SITEMAP);
+            $fromCache = $this->cache->has($this->sitemapConfig->getCacheKeySitemap());
         } catch (InvalidArgumentException $e) {
             $fromCache = false;
         }
 
-        $path = storage_path(self::VDLP_SITEMAP_PATH);
+        $path = storage_path($this->sitemapConfig->getCacheFilePath());
 
         $fileExists = file_exists($path);
 
@@ -60,19 +58,19 @@ final class SitemapGenerator implements SitemapGeneratorInterface
             $fromCache = false;
         }
 
-        if ($fromCache || file_exists($path)) {
+        if ($fromCache && file_exists($path)) {
             return;
         }
 
         $this->createXmlFile($this->rememberDefinitionsFromCache(), $path);
-        $this->updateCache(self::CACHE_KEY_SITEMAP, true);
+        $this->updateCache($this->sitemapConfig->getCacheKeySitemap(), true);
     }
 
     public function output(): void
     {
         header('Content-Type: application/xml');
 
-        $handle = fopen(storage_path(self::VDLP_SITEMAP_PATH), 'rb');
+        $handle = fopen(storage_path($this->sitemapConfig->getCacheFilePath()), 'rb');
 
         if ($handle === false) {
             exit(1);
@@ -110,7 +108,7 @@ final class SitemapGenerator implements SitemapGeneratorInterface
             throw new DtoNotFound();
         }
 
-        $this->updateCache(self::CACHE_DEFINITIONS, $definitions);
+        $this->updateCache($this->sitemapConfig->getCacheKeyDefinitions(), $definitions);
         $this->invalidateSitemapCache();
     }
 
@@ -122,7 +120,7 @@ final class SitemapGenerator implements SitemapGeneratorInterface
 
         $definitions = $this->rememberDefinitionsFromCache();
         $definitions->addItem($definition);
-        $this->updateCache(self::CACHE_DEFINITIONS, $definitions);
+        $this->updateCache($this->sitemapConfig->getCacheKeyDefinitions(), $definitions);
         $this->invalidateSitemapCache();
     }
 
@@ -139,7 +137,7 @@ final class SitemapGenerator implements SitemapGeneratorInterface
     {
         $definitions = $this->rememberDefinitionsFromCache();
         $definitions->removeDefinitionByUrl($url);
-        $this->updateCache(self::CACHE_DEFINITIONS, $definitions);
+        $this->updateCache($this->sitemapConfig->getCacheKeyDefinitions(), $definitions);
         $this->invalidateSitemapCache();
     }
 
@@ -192,7 +190,7 @@ final class SitemapGenerator implements SitemapGeneratorInterface
         }
 
         fwrite($file, '<?xml version="1.0" encoding="UTF-8" ?>');
-        fwrite($file, '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">');
+        fwrite($file, '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">');
 
         /** @var Dto\Definition $definition */
         foreach ($definitions->getItems() as $definition) {
@@ -212,6 +210,17 @@ final class SitemapGenerator implements SitemapGeneratorInterface
 
             if ($definition->getChangeFrequency() !== null) {
                 $xml .= '<changefreq>' . $definition->getChangeFrequency() . '</changefreq>';
+            }
+
+            foreach ($definition->getImages() as $image) {
+                $xml .= '<image:image>';
+                $xml .= '<image:loc>' . $image->getUrl() . '</image:loc>';
+
+                if ($image->getTitle() !== null) {
+                    $xml .= '<image:title>' . $image->getTitle() . '</image:title>';
+                }
+
+                $xml .= '</image:image>';
             }
 
             $xml .= '</url>';
@@ -284,47 +293,41 @@ final class SitemapGenerator implements SitemapGeneratorInterface
         return $flatArray;
     }
 
-    /**
-     * @param mixed $value
-     */
-    private function updateCache(string $key, $value): void
+    private function updateCache(string $key, mixed $value): void
     {
-        if ($this->cacheForever) {
+        if ($this->sitemapConfig->isCacheForever()) {
             $this->cache->forever($key, $value);
         }
 
-        $this->cache->put($key, $value, $this->cacheTime);
+        $this->cache->put($key, $value, $this->sitemapConfig->getCacheTime());
     }
 
     private function rememberDefinitionsFromCache(): Definitions
     {
         /** @var Definitions $definitions */
-        $definitions = $this->rememberFromCache(self::CACHE_DEFINITIONS, function (): Definitions {
+        $definitions = $this->rememberFromCache($this->sitemapConfig->getCacheKeyDefinitions(), function (): Definitions {
             return $this->getDefinitions();
         });
 
         return $definitions;
     }
 
-    /**
-     * @return mixed
-     */
-    private function rememberFromCache(string $key, Closure $closure)
+    private function rememberFromCache(string $key, Closure $closure): mixed
     {
-        if ($this->cacheForever) {
+        if ($this->sitemapConfig->isCacheForever()) {
             return $this->cache->rememberForever($key, $closure);
         }
 
-        return $this->cache->remember($key, $this->cacheTime, $closure);
+        return $this->cache->remember($key, $this->sitemapConfig->getCacheTime(), $closure);
     }
 
     private function invalidateSitemapCache(): bool
     {
-        return $this->cache->forget(self::CACHE_KEY_SITEMAP);
+        return $this->cache->forget($this->sitemapConfig->getCacheKeySitemap());
     }
 
     private function invalidateDefinitionsCache(): bool
     {
-        return $this->cache->forget(self::CACHE_DEFINITIONS);
+        return $this->cache->forget($this->sitemapConfig->getCacheKeyDefinitions());
     }
 }

--- a/classes/contracts/ConfigResolver.php
+++ b/classes/contracts/ConfigResolver.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vdlp\Sitemap\Classes\Contracts;
+
+use Vdlp\Sitemap\Classes\Dto\SitemapConfig;
+
+interface ConfigResolver
+{
+    public function getConfig(): SitemapConfig;
+}

--- a/classes/dto/Definition.php
+++ b/classes/dto/Definition.php
@@ -24,6 +24,11 @@ final class Definition implements Dto
     private ?Carbon $modifiedAt = null;
 
     /**
+     * @var ImageDefinition[]
+     */
+    private array $images = [];
+
+    /**
      * @throws InvalidPriority
      */
     public static function fromArray(array $data): Dto
@@ -96,5 +101,30 @@ final class Definition implements Dto
     public function getModifiedAt(): ?Carbon
     {
         return $this->modifiedAt;
+    }
+
+    /**
+     * @return ImageDefinition[]
+     */
+    public function getImages(): array
+    {
+        return $this->images;
+    }
+
+    /**
+     * @param ImageDefinition[] $images
+     */
+    public function setImages(array $images): Definition
+    {
+        $this->images = $images;
+
+        return $this;
+    }
+
+    public function addImage(ImageDefinition $image): Definition
+    {
+        $this->images[] = $image;
+
+        return $this;
     }
 }

--- a/classes/dto/Definition.php
+++ b/classes/dto/Definition.php
@@ -56,7 +56,7 @@ final class Definition implements Dto
      */
     public function setPriority(?int $priority): Definition
     {
-        if ($priority >= 1 && $priority <= 10) {
+        if ($priority >= 0 && $priority <= 10) {
             $this->priority = $priority;
 
             return $this;

--- a/classes/dto/ImageDefinition.php
+++ b/classes/dto/ImageDefinition.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vdlp\Sitemap\Classes\Dto;
+
+use Vdlp\Sitemap\Classes\Contracts\Dto;
+
+final class ImageDefinition implements Dto
+{
+    public function __construct(
+        private string $url,
+        private ?string $title = null
+    ) {
+    }
+
+    public static function fromArray(array $data): ImageDefinition
+    {
+        return new self($data['url'] ?? '', $data['title'] ?? null);
+    }
+
+    public function getUrl(): string
+    {
+        return $this->url;
+    }
+
+    public function setUrl(string $url): ImageDefinition
+    {
+        $this->url = $url;
+
+        return $this;
+    }
+
+    public function getTitle(): ?string
+    {
+        return $this->title;
+    }
+
+    public function setTitle(?string $title): ImageDefinition
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+}

--- a/classes/dto/SitemapConfig.php
+++ b/classes/dto/SitemapConfig.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vdlp\Sitemap\Classes\Dto;
+
+final class SitemapConfig
+{
+    public function __construct(
+        private string $cacheKeySitemap,
+        private string $cacheKeyDefinitions,
+        private string $cacheFilePath,
+        private int $cacheTime,
+        private bool $cacheForever
+    ) {
+    }
+
+    public function getCacheKeySitemap(): string
+    {
+        return $this->cacheKeySitemap;
+    }
+
+    public function getCacheKeyDefinitions(): string
+    {
+        return $this->cacheKeyDefinitions;
+    }
+
+    public function getCacheFilePath(): string
+    {
+        return $this->cacheFilePath;
+    }
+
+    public function getCacheTime(): int
+    {
+        return $this->cacheTime;
+    }
+
+    public function isCacheForever(): bool
+    {
+        return $this->cacheForever;
+    }
+}

--- a/classes/resolvers/StaticConfigResolver.php
+++ b/classes/resolvers/StaticConfigResolver.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vdlp\Sitemap\Classes\Resolvers;
+
+use Illuminate\Contracts\Config\Repository;
+use Vdlp\Sitemap\Classes\Contracts\ConfigResolver;
+use Vdlp\Sitemap\Classes\Dto\SitemapConfig;
+
+final class StaticConfigResolver implements ConfigResolver
+{
+    public function __construct(private Repository $repository)
+    {
+    }
+
+    public function getConfig(): SitemapConfig
+    {
+        return new SitemapConfig(
+            'vdlp_sitemap_cache',
+            'vdlp_sitemap_definitions',
+            'vdlp/sitemap/sitemap.xml',
+            (int) $this->repository->get('sitemap.cache_time', 3600),
+            (bool) $this->repository->get('sitemap.cache_forever', false)
+        );
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -30,5 +30,10 @@
             ".github",
             ".gitignore"
         ]
+    },
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
+        "php": "^8.0",
         "composer/installers": "^1.0 || ^2.0",
-        "october/system": "^1.1 || ^2.2"
+        "october/system": ">=1.1"
     },
     "suggest": {
         "vdlp/oc-sitemapgenerators-plugin": "Adds pre-built sitemap generators for your October CMS website."

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "^8.0.2",
         "composer/installers": "^1.0 || ^2.0",
-        "october/system": "^2.2"
+        "october/system": "^1.1 || ^2.2"
     },
     "suggest": {
         "vdlp/oc-sitemapgenerators-plugin": "Adds pre-built sitemap generators for your October CMS website."

--- a/config.php
+++ b/config.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Vdlp\Sitemap\Classes\Resolvers\StaticConfigResolver;
+
 return [
 
     /*
@@ -27,5 +29,15 @@ return [
     */
 
     'cache_forever' => env('VDLP_SITEMAP_CACHE_FOREVER', false),
+
+    /*
+     |--------------------------------------------------------------------------
+     | Config resolver
+     |--------------------------------------------------------------------------
+     |
+     | Configure how the sitemap config should be resolved.
+     |
+     */
+    'config_resolver' => StaticConfigResolver::class,
 
 ];

--- a/routes.php
+++ b/routes.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Illuminate\Contracts\Routing\ResponseFactory;
 use Illuminate\Routing;
 use Psr\Log\LoggerInterface;
 use Vdlp\Sitemap\Classes\Contracts\SitemapGenerator;
@@ -9,15 +10,19 @@ use Vdlp\Sitemap\Classes\Contracts\SitemapGenerator;
 /** @var Routing\Router $router */
 $router = resolve(Routing\Router::class);
 
-$router->get('sitemap.xml', static function (): void {
+$router->get('sitemap.xml', static function (ResponseFactory $responseFactory): mixed {
     try {
         /** @var SitemapGenerator $generator */
         $generator = resolve(SitemapGenerator::class);
         $generator->generate();
         $generator->output();
-    } catch (Throwable $e) {
+    } catch (Throwable $throwable) {
         /** @var LoggerInterface $log */
         $log = resolve(LoggerInterface::class);
-        $log->error('Vdlp.Sitemap: Unable to serve sitemap.xml: ' . $e->getMessage());
+        $log->error('Vdlp.Sitemap: Unable to serve sitemap.xml: ' . $throwable->getMessage(), [
+            'exception' => $throwable,
+        ]);
+
+        return $responseFactory->make('', 500);
     }
 });

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -5,3 +5,4 @@ v1.0.3: Code cleanup
 v1.1.0: Update plugin dependencies
 v2.0.0: "Add support for PHP 7.4 or higher. Please review plugin configuration, check README.md"
 v2.1.0: "Maintenance update. Check CHANGELOG.md for details."
+v2.2.0: "Add sitemap config resolver and images. Fixed bug where sitemap would never regenerate when sitemap file exists."


### PR DESCRIPTION
Added:

- Add support for images.
- Add sitemap config resolver to configure the sitemap config on runtime. This can be useful for multisite projects.
- Add support for oc 1.
- Add support for priority zero.

Fixed:
- Fixed bug where sitemap would never regenerate when sitemap file exists.
- Escape illegal xml characters in loc and title elements.
- Improve exception logging and show 500 error when an error occurs.